### PR TITLE
DynaFed compatibility; Elements naming; Typos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 CommerceBlock
+Copyright (c) 2022 Tranquility Node Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Federation
+# Elements Federation
 
-The client used by the federation nodes of the Ocean network performing block generation and signing, token inflation, and other functions.
+The client used by the federation nodes of an Elements network performing block generation and signing, token inflation, and other functions.
 
 ## Instructions
 1. `pip3 install -r requirements.txt`
 2. `python3 setup.py build && python3 setup.py install`
 3. For the demo run `./run_demo` or `python3 -m demo`
 4. For the federation run `./run_federation` or `python3 -m federation` and provide the following arguments:
-`--rpcconnect $HOST --rpocport $PORT --rpcuser $USER --rpcpass $PASS --id $NODE_ID --msgtype $MSG_TYPE --nodes $NODES_LIST`
+`--rpcconnect $HOST --rpcport $PORT --rpcuser $USER --rpcpass $PASS --id $NODE_ID --msgtype $MSG_TYPE --nodes $NODES_LIST`
 
 Federation arguments:
 
-- `--rpconnect`: rpc host of Ocean node
-- `--rpcport`: rpc port of Ocean node
+- `--rpcconnect`: rpc host of Elements node
+- `--rpcport`: rpc port of Elements node
 - `--rpcuser`: rpc username
 - `--rpcpassword`: rpc password
 - `--id`: federation node id
@@ -27,8 +27,8 @@ Federation arguments:
 
 Example use:
 
-- zmq: `python3 -m federation --rpconnect 127.0.0.1 --rpcport 18443 --rpcuser user --rpcpass pass --id 1 --msgtype zmq --nodes “node0:1503,node1:1502”`
-- kafka: `python3 -m federation --rpconnect 127.0.0.1 --rpcport 18443 --rpcuser user --rpcpass pass --id 1` (check federation.py - defaults to 5 nodes)
+- zmq: `python3 -m federation --rpcconnect 127.0.0.1 --rpcport 18443 --rpcuser user --rpcpass pass --id 1 --msgtype zmq --nodes “node0:1503,node1:1502”`
+- kafka: `python3 -m federation --rpcconnect 127.0.0.1 --rpcport 18443 --rpcuser user --rpcpass pass --id 1` (check federation.py - defaults to 5 nodes)
 
 ### Using HSMs
 
@@ -38,7 +38,7 @@ Assuming hsm and pkcs11 libraries setup and all config/secrets files are in plac
 
 `docker build --build-arg user_pin=$USER_PIN --build-arg key_label=$KEY_LABEL -f Dockerfile.hsm.init .`
 
-This will generate a multisig script that should be used as the `signblockarg` in the ocean sidechain.
+This will generate a multisig script that should be used as the `signblockarg` in the elements sidechain.
 
 #### Running
 
@@ -48,8 +48,8 @@ To build the federation container with hsm signing run:
 
 Inside this container federation can be initiated by:
 
-`python3 -u -m federation --rpconnect signing1 --rpcport 18886 --rpcuser username1 --rpcpass password1 --id 1 --msgtype zmq --nodes "federation0:6666,federation1:7777,federation2:8888" --hsm 1`
+`python3 -u -m federation --rpcconnect signing1 --rpcport 18886 --rpcuser username1 --rpcpass password1 --id 1 --msgtype zmq --nodes "federation0:6666,federation1:7777,federation2:8888" --hsm 1`
 
 ### Inflating assets
 
-The federation nodes can be used to reissue issued assets according to a fixed inflation schedule. This is enabled by setting the `--inflationrate` argument to a non zero value. The assets are then reissued every `--inflationperiod` blocks, and to the specified address. The reissuance tokens must be paid to the P2SH address of the supplied multisig script (`--reissuancescript`). The corresponding private key for the signing node (for the reissuance script) is supplied as `--reissuanceprivkey`. If inflation is enabled, the `-rescan=1` and `-recordinflation=1` flags must be set in the signing node `ocean.conf` file. 
+The federation nodes can be used to reissue issued assets according to a fixed inflation schedule. This is enabled by setting the `--inflationrate` argument to a non zero value. The assets are then reissued every `--inflationperiod` blocks, and to the specified address. The reissuance tokens must be paid to the P2SH address of the supplied multisig script (`--reissuancescript`). The corresponding private key for the signing node (for the reissuance script) is supplied as `--reissuanceprivkey`. If inflation is enabled, the `-rescan=1` and `-recordinflation=1` flags must be set in the signing node `elementsd.conf` file. 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,6 @@
 # Protocol Demo
 
-A demonstration of protocols used by the Ocean network, including federated signing and asset issuance.
+A demonstration of protocols used by the Elements network, including federated signing and asset issuance.
 
 ## Instructions
 

--- a/demo/assetissuance.py
+++ b/demo/assetissuance.py
@@ -2,20 +2,20 @@
 import threading
 import time
 import random
-from federation.connectivity import getoceand
+from federation.connectivity import getelementsd
 
 ISSUANCE = 10000000
 REISSUANCE = 0
 
 class AssetIssuance(threading.Thread):
-    def __init__(self, ocean_conf, interval):
+    def __init__(self, elementsd_conf, interval):
         threading.Thread.__init__(self)
         self.stop_event = threading.Event()
         self.daemon = True
-        self.ocean_conf = ocean_conf
-        self.ocean = getoceand(ocean_conf)
+        self.elementsd_conf = elementsd_conf
+        self.elementsd = getelementsd(elementsd_conf)
         self.interval = interval
-        issue = self.ocean.issueasset(ISSUANCE, REISSUANCE, False)
+        issue = self.elementsd.issueasset(ISSUANCE, REISSUANCE, False)
         self.asset = issue["asset"]
         time.sleep(5)
 
@@ -24,10 +24,10 @@ class AssetIssuance(threading.Thread):
 
     def run(self):
         while not self.stop_event.is_set():
-            self.ocean = getoceand(self.ocean_conf)
-            addr = self.ocean.getnewaddress()
+            self.elementsd = getelementsd(self.elementsd_conf)
+            addr = self.elementsd.getnewaddress()
             time.sleep(2)
-            self.ocean.sendtoaddress(addr, random.randint(1,10), "", "", False, self.asset)
+            self.elementsd.sendtoaddress(addr, random.randint(1,10), "", "", False, self.asset)
             time.sleep(2)
             time.sleep(self.interval)
 

--- a/demo/client.py
+++ b/demo/client.py
@@ -12,11 +12,11 @@ REISSUANCE_AMOUNT = 50
 REISSUANCE_TOKEN = 1
 
 class Client(DaemonThread):
-    def __init__(self, oceandir, numofclients, args, script, inflate, freecoinkey=""):
+    def __init__(self, elementsddir, numofclients, args, script, inflate, freecoinkey=""):
         super().__init__()
         self.logger = logging.getLogger(self.__class__.__name__)
         self.doinf = inflate
-        self.ocean_conf = [None]*numofclients
+        self.elementsd_conf = [None]*numofclients
         self.num_of_clients = numofclients
         self.assets = [None]*numofclients
         self.issuers = []
@@ -24,19 +24,19 @@ class Client(DaemonThread):
         self.inflate = inflate
         self.script = script
 
-        for i in range(0, self.num_of_clients): # spawn ocean signing node
+        for i in range(0, self.num_of_clients): # spawn elementsd signing node
             datadir = self.tmpdir + "/client" + str(i)
             os.makedirs(datadir)
-            os.makedirs(datadir + "/terms-and-conditions/ocean_test")
+            os.makedirs(datadir + "/terms-and-conditions/elementsd_test")
 
-            confdir = os.path.join(os.path.dirname(__file__), "client"+str(i)+"/ocean.conf")
-            shutil.copyfile(confdir, datadir+"/ocean.conf")
-            shutil.copyfile(os.path.join(os.path.dirname(__file__), 'latest.txt'), datadir + "/terms-and-conditions/ocean_test/latest.txt")
+            confdir = os.path.join(os.path.dirname(__file__), "client"+str(i)+"/elementsd.conf")
+            shutil.copyfile(confdir, datadir+"/elementsd.conf")
+            shutil.copyfile(os.path.join(os.path.dirname(__file__), 'latest.txt'), datadir + "/terms-and-conditions/elementsd_test/latest.txt")
             mainconf = loadConfig(confdir)
 
             self.logger.info("Starting node {} with datadir {} and confdir {}".format(i, datadir, confdir))
-            e = startoceand(oceandir, datadir, mainconf, args)
-            self.ocean_conf[i] = ((mainconf, e))
+            e = startelementsd(elementsddir, datadir, mainconf, args)
+            self.elementsd_conf[i] = ((mainconf, e))
             time.sleep(10)
 
             if self.inflate:
@@ -56,8 +56,8 @@ class Client(DaemonThread):
                 self.assets[i] = issue["asset"]
 
     def stop(self):
-        for ocean in self.ocean_conf:
-            ocean[1].stop()
+        for elementsd in self.elementsd_conf:
+            elementsd[1].stop()
         shutil.rmtree(self.tmpdir)
         for issuer in self.issuers:
             issuer.stop()
@@ -69,26 +69,26 @@ class Client(DaemonThread):
         while not self.stopped():
             if not self.inflate:
                 # get random addr from nodes
-                addr = getoceand(self.ocean_conf[random.randint(0,self.num_of_clients-1)][0]).getnewaddress()
+                addr = getelementsd(self.elementsd_conf[random.randint(0,self.num_of_clients-1)][0]).getnewaddress()
                 time.sleep(2)
 
                 # reconnect to avoid any previous failures
-                ocean_client = getoceand(self.ocean_conf[send_turn][0])
-                ocean_client.sendtoaddress(addr, random.randint(1,10), "", "", False, self.assets[send_turn])
+                elementsd_client = getelementsd(self.elementsd_conf[send_turn][0])
+                elementsd_client.sendtoaddress(addr, random.randint(1,10), "", "", False, self.assets[send_turn])
                 time.sleep(2)
-                ocean_client.reissueasset(self.assets[send_turn], REISSUANCE_AMOUNT)
+                elementsd_client.reissueasset(self.assets[send_turn], REISSUANCE_AMOUNT)
                 send_turn = (send_turn + 1) % self.num_of_clients
             else:
-                ocean_client = getoceand(self.ocean_conf[send_turn][0])
-                addr = ocean_client.getnewaddress()
-                addr2 = ocean_client.getnewaddress()
-                p2sh = ocean_client.decodescript(self.script)
+                elementsd_client = getelementsd(self.elementsd_conf[send_turn][0])
+                addr = elementsd_client.getnewaddress()
+                addr2 = elementsd_client.getnewaddress()
+                p2sh = elementsd_client.decodescript(self.script)
                 token_addr = p2sh["p2sh"]
-                rawissue = ocean_client.createrawissuance(addr,str(10.0),token_addr,'10000',addr2,'210000','1',self.issue_txid,str(self.issue_vout))
-                sign_issue = ocean_client.signrawtransaction(rawissue["rawtx"])
-                self.issue_txid = ocean_client.sendrawtransaction(sign_issue["hex"])
+                rawissue = elementsd_client.createrawissuance(addr,str(10.0),token_addr,'10000',addr2,'210000','1',self.issue_txid,str(self.issue_vout))
+                sign_issue = elementsd_client.signrawtransaction(rawissue["rawtx"])
+                self.issue_txid = elementsd_client.sendrawtransaction(sign_issue["hex"])
                 self.logger.info("issued 210000 "+str(self.issue_txid))
-                issue_decode = ocean_client.decoderawtransaction(sign_issue["hex"])
+                issue_decode = elementsd_client.decoderawtransaction(sign_issue["hex"])
                 for out in issue_decode["vout"]:
                     if out["value"] == 210000.0:
                         self.issue_vout = out["n"]
@@ -96,7 +96,7 @@ class Client(DaemonThread):
             time.sleep(WAIT_TIME)
 
 if __name__ == "__main__":
-    path = "oceand"
+    path = "elementsd"
     c = Client(path)
     c.start()
 

--- a/demo/client0/elementsd.conf
+++ b/demo/client0/elementsd.conf
@@ -1,20 +1,17 @@
-rpcuser=bitcoinrpc
-rpcpassword=acc1e7a299bc49449912e235b54dbce5
-rpcport=18886
-port=10001
-rpcallowip=0.0.0.0/0
+rpcuser=user000
+rpcpassword=password000
+rpcport=18800
+port=18801
 
 addnode=localhost:18889
 addnode=localhost:18891
 addnode=localhost:18893
-addnode=localhost:18801
 addnode=localhost:18803
 
 initialfreecoins=2100000000000000
 policycoins=2100000000000000
-chain=ocean_test
-server=1
+chain=elements_test
+recordinflation=1
 daemon=1
 listen=1
 txindex=1
-disablewallet=1

--- a/demo/client1/elementsd.conf
+++ b/demo/client1/elementsd.conf
@@ -10,7 +10,7 @@ addnode=localhost:18801
 
 initialfreecoins=2100000000000000
 policycoins=2100000000000000
-chain=ocean_test
+chain=elements_test
 recordinflation=1
 daemon=1
 listen=1

--- a/demo/explorer/elementsd.conf
+++ b/demo/explorer/elementsd.conf
@@ -1,17 +1,20 @@
-rpcuser=user000
-rpcpassword=password000
-rpcport=18800
-port=18801
+rpcuser=bitcoinrpc
+rpcpassword=acc1e7a299bc49449912e235b54dbce5
+rpcport=18886
+port=10001
+rpcallowip=0.0.0.0/0
 
 addnode=localhost:18889
 addnode=localhost:18891
 addnode=localhost:18893
+addnode=localhost:18801
 addnode=localhost:18803
 
 initialfreecoins=2100000000000000
 policycoins=2100000000000000
-chain=ocean_test
-recordinflation=1
+chain=elements_test
+server=1
 daemon=1
 listen=1
 txindex=1
+disablewallet=1

--- a/demo/main0/elementsd.conf
+++ b/demo/main0/elementsd.conf
@@ -1,18 +1,18 @@
 # Standard bitcoind stuff
-rpcuser=user4
-rpcpassword=password4
-rpcport=18890
-port=18891
+rpcuser=user1
+rpcpassword=password1
+rpcport=18892
+port=18893
 
 # Over p2p we will only connect to local other oceand
-connect=localhost:18893
 connect=localhost:18889
+connect=localhost:18891
 connect=localhost:18801 # non signing node 0
 connect=localhost:18803 # non signing node 1
 
 initialfreecoins=2100000000000000
 policycoins=2100000000000000
-chain=ocean_test
+chain=elements_test
 recordinflation=1
 daemon=1
 listen=1

--- a/demo/main1/elementsd.conf
+++ b/demo/main1/elementsd.conf
@@ -1,18 +1,18 @@
 # Standard bitcoind stuff
-rpcuser=user1
-rpcpassword=password1
-rpcport=18892
-port=18893
+rpcuser=user3
+rpcpassword=password3
+rpcport=18888
+port=18889
 
 # Over p2p we will only connect to local other oceand
-connect=localhost:18889
+connect=localhost:18893
 connect=localhost:18891
 connect=localhost:18801 # non signing node 0
 connect=localhost:18803 # non signing node 1
 
 initialfreecoins=2100000000000000
 policycoins=2100000000000000
-chain=ocean_test
+chain=elements_test
 recordinflation=1
 daemon=1
 listen=1

--- a/demo/main2/elementsd.conf
+++ b/demo/main2/elementsd.conf
@@ -1,18 +1,18 @@
 # Standard bitcoind stuff
-rpcuser=user3
-rpcpassword=password3
-rpcport=18888
-port=18889
+rpcuser=user4
+rpcpassword=password4
+rpcport=18890
+port=18891
 
 # Over p2p we will only connect to local other oceand
 connect=localhost:18893
-connect=localhost:18891
+connect=localhost:18889
 connect=localhost:18801 # non signing node 0
 connect=localhost:18803 # non signing node 1
 
 initialfreecoins=2100000000000000
 policycoins=2100000000000000
-chain=ocean_test
+chain=elements_test
 recordinflation=1
 daemon=1
 listen=1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-if [ -f /run/secrets/ocean_user ] && [ -f /run/secrets/ocean_pass ]; then
-    creds=("--rpcuser=$(cat /run/secrets/ocean_user)" "--rpcpassword=$(cat /run/secrets/ocean_pass)")
-elif [ -f /run/secrets/ocean_pass ] && [ -f /run/secrets/reissuance_priv_key ]; then
-    creds=("--rpcpassword=$(cat /run/secrets/ocean_pass)" "--reissuanceprivkey=$(cat /run/secrets/reissuance_priv_key)")
-elif [ -f /run/secrets/ocean_pass ]; then
-    creds=("--rpcpassword=$(cat /run/secrets/ocean_pass)")
+if [ -f /run/secrets/elementsd_user ] && [ -f /run/secrets/elementsd_pass ]; then
+    creds=("--rpcuser=$(cat /run/secrets/elementsd_user)" "--rpcpassword=$(cat /run/secrets/elementsd_pass)")
+elif [ -f /run/secrets/elementsd_pass ] && [ -f /run/secrets/reissuance_priv_key ]; then
+    creds=("--rpcpassword=$(cat /run/secrets/elementsd_pass)" "--reissuanceprivkey=$(cat /run/secrets/reissuance_priv_key)")
+elif [ -f /run/secrets/elementsd_pass ]; then
+    creds=("--rpcpassword=$(cat /run/secrets/elementsd_pass)")
 fi
 
 command="$@ ${creds[@]}"

--- a/federation/connectivity.py
+++ b/federation/connectivity.py
@@ -7,11 +7,11 @@ import subprocess
 import shutil
 from .test_framework.authproxy import AuthServiceProxy, JSONRPCException
 
-def startoceand(oceanpath, datadir, conf, args=""):
-    subprocess.Popen((oceanpath+"  -datadir="+datadir+" "+args).split(), stdout=subprocess.PIPE)
-    return getoceand(conf)
+def startelementsd(elementsdpath, datadir, conf, args=""):
+    subprocess.Popen((elementsdpath+"  -datadir="+datadir+" "+args).split(), stdout=subprocess.PIPE)
+    return getelementsd(conf)
 
-def getoceand(conf):
+def getelementsd(conf):
     if "rpcconnect" in conf:
         rpcconnect = conf["rpcconnect"]
     else:

--- a/federation/federation.py
+++ b/federation/federation.py
@@ -12,11 +12,11 @@ from pdb import set_trace
 from .test_framework.authproxy import AuthServiceProxy, JSONRPCException
 from .blocksigning import BlockSigning
 from .hsm import HsmPkcs11
-from .connectivity import getoceand, loadConfig
+from .connectivity import getelementsd, loadConfig
 
-NUM_OF_NODES_DEFAULT = 5
-NUM_OF_SIGS_DEFAULT = 3
-MESSENGER_TYPE_DEFAULT = "kafka"
+NUM_OF_NODES_DEFAULT = 9
+NUM_OF_SIGS_DEFAULT = 6
+MESSENGER_TYPE_DEFAULT = "zmq"
 IN_RATE = 0
 IN_PERIOD = 0
 IN_ADDRESS = ""
@@ -25,7 +25,7 @@ PRVKEY = ""
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--rpconnect', required=True, type=str, help="Client RPC host")
+    parser.add_argument('--rpcconnect', required=True, type=str, help="Client RPC host")
     parser.add_argument('--rpcport', required=True, type=str, help="Client RPC port")
     parser.add_argument('--rpcuser', required=True, type=str, help="RPC username for client")
     parser.add_argument('--rpcpassword', required=True, type=str, help="RPC password for client")
@@ -55,7 +55,7 @@ def main():
     conf["rpcuser"] = args.rpcuser
     conf["rpcpassword"] = args.rpcpassword
     conf["rpcport"] = args.rpcport
-    conf["rpcconnect"] = args.rpconnect
+    conf["rpcconnect"] = args.rpcconnect
     conf["id"] = args.id
     conf["msgtype"] = args.msgtype
     conf["nsigs"] = NUM_OF_SIGS_DEFAULT

--- a/federation/test_framework/util.py
+++ b/federation/test_framework/util.py
@@ -186,7 +186,7 @@ def initialize_datadir(dirname, n):
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     rpc_u, rpc_p = rpc_auth_pair(n)
-    with open(os.path.join(datadir, "ocean.conf"), 'w', encoding='utf8') as f:
+    with open(os.path.join(datadir, "elementsd.conf"), 'w', encoding='utf8') as f:
         f.write("regtest=1\n")
         f.write("rpcuser=" + rpc_u + "\n")
         f.write("rpcpassword=" + rpc_p + "\n")
@@ -254,7 +254,7 @@ def initialize_chain(test_dir, num_nodes, cachedir):
         # Create cache directories, run bitcoinds:
         for i in range(MAX_NODES):
             datadir=initialize_datadir(cachedir, i)
-            args = [ os.getenv("OCEAND", "oceand"), "-server", "-keypool=1", "-datadir="+datadir, "-discover=0" ]
+            args = [ os.getenv("ELEMENTSD", "elementsd"), "-server", "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args)
@@ -340,7 +340,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     """
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
-        binary = os.getenv("OCEAND", "oceand")
+        binary = os.getenv("ELEMENTSD", "elementsd")
     args = [ binary, "-datadir="+datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-mocktime="+str(get_mocktime()) ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
@@ -373,7 +373,7 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, timewait=None
     return rpcs
 
 def log_filename(dirname, n_node, logname):
-    return os.path.join(dirname, "node"+str(n_node), "oceanregtest", logname)
+    return os.path.join(dirname, "node"+str(n_node), "elementsregtest", logname)
 
 def stop_node(node, i):
     try:

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,11 @@
 from setuptools import setup, find_packages
 import os
 
-setup(name='federation',
+setup(name='elements-federation',
       version='0.1',
       description='Federation Node Daemon',
-      author='CommerceBlock',
-      author_email='nikolaos@commerceblock.com',
-      url='http://github.com/commerceblock/federation',
+      author='Originally CommerceBlock, modified by Tranquility Node Ltd',
+      url='http://github.com/tranquilitynode/elements-federation',
       packages=find_packages(),
       scripts=[],
       include_package_data=True,


### PR DESCRIPTION
This commitment branches CommerceBlock's federation package which is designed for their Ocean fork of Elements, to be compatible with modern Elements versions which include the DynaFed hard fork.

It updates references from Ocean to Elements

The argument '--rpconnect' becomes '--rpcconect' and some other typos in argument help files get tidied up.

NB, The new REDEEM_SCRIPT parameter in block signing.py must be manually changed by all federation members. Future updates may make this dynamic.